### PR TITLE
Proposed printer.cfg edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,21 @@ The latest Raspberry Pi imager V1.7.1 and higher lets us set the username and pa
 Also SSH can be enabled from the imager. This is done through the Settings gearwheel in the bottom right corner.
 Mainsail can now be downloaded and installed directly through the Raspberry Pi Imager
 ```
-## Find the applicable CR6.cfg file and the Printer.<motherboard>.cfg files in (the Klipper_config folder of this repository)[https://github.com/KoenVanduffel/CR-6_Klipper/tree/main/klipper_config]
+## Find the applicable CR6.cfg file and the Printer._motherboard_.cfg files in (the Klipper_config folder of this repository)[https://github.com/KoenVanduffel/CR-6_Klipper/tree/main/klipper_config]
 
 In the klipper_config folder of this repo, you will find the following files:
 * CR6.cfg - contains the Klipper software configuration information specific to our CR6 printer.  
   Use that file for all motherboards.
-* Multiple files with the name Printer.<motherboard>.cfg
-  , where <motherboard> is the name of the motherboard supported by that particular file (e.g. printer.Creality-4.5.3.cfg is the file to use if you have either the 4.5.3 or the 1.1.0.3-ERA motherboard from Creality.)  Use ONLY the printer.<motherboard>.cfg named for your motherboard.
+* Multiple files with the name Printer._motherboard_.cfg
+  , where _motherboard_ is the name of the motherboard supported by that particular file (e.g. printer.Creality-4.5.3.cfg is the file to use if you have either the 4.5.3 or the 1.1.0.3-ERA motherboard from Creality.)  Use ONLY the printer._motherboard_.cfg named for your motherboard.
 
 ##  Install those two cfg files onto the pi
  
 Copy CR6.cfg to /home/pi/klipper_config on the pi
 Do NOT rename that file
 
-Copy the appropriate printer.<motherboard>.cfg file to /home/pi/klipper_config on the pi
-Rename that file from "printer.<motherboard>.cfg" to "klipper.cfg"
+Copy the appropriate printer._motherboard_.cfg file to /home/pi/klipper_config on the pi
+Rename that file from "printer._motherboard_.cfg" to "klipper.cfg"
 
 ## Now make the Klipper firmware.bin file that you will flash to the printer mainboard
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 PLEASE NOTE: 
 * This GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  
 * This is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
-* YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU (NOTE, though, that NERO3D uses Balener Etcher instead of the Raspberry Pi Imager, in his install)
+* YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU (NOTE, though, that NERO3D uses [Balena Etcher](https://www.balena.io/etcher/) instead of the Raspberry Pi Imager, to flash Fluidd to his SD.)
 
 This repo focusses on using Klipper with the Fluidd front end. 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Here is Help for Installing and Configuring Klipper on CR6 printers
 
 PLEASE NOTE: 
-* The intention of this GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  
+* This GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  
 * This is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
 * YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU (NOTE, though, that NERO3D uses Balener Etcher instead of the Raspberry Pi Imager, in his install)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 PLEASE NOTE: 
 * This GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  
 * This is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
-* YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU (NOTE, though, that NERO3D uses [Balena Etcher](https://www.balena.io/etcher/) instead of the Raspberry Pi Imager, to flash Fluidd to his SD.)
+* YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU 
+* NERO3D uses [Balena Etcher](https://www.balena.io/etcher/) instead of the Raspberry Pi Imager, to flash Fluidd to his SD. Either should be ok.  In this author's experience, though, Raspberry Pi Imager succeeded where Balena Etcher consistently reported, "flash Failed!"
 
 This repo focusses on using Klipper with the Fluidd front end. 
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ Klipper is a complete package to run your 3D printer consisting of 3 main tools:
 * Moonraker: The broker. Moonraker handles the communication between Klippy, the visual front end(s) and hardware on the rPi.
 * Fluidd/Mainsail/KlipperScreen: The Klipper display and User Interface. These all 3 do more or less the same (you only need one of them but can run all 3 if wanted). They are the user interface where we put/upload our gcode files, do all calibrations, view a bed mesh and so on.
 
-## Installation description:
-
-Download the FluidPI or Mainsail image from the FluiddPI or Mainsail GitHub repo:
+## Where to Download Klipper:
+Download the FluidPI or Mainsail image of the Klipper package from the FluiddPI or Mainsail GitHub repo:
 * https://github.com/cadriel/FluiddPI/releases/
 * https://github.com/mainsail-crew/mainsailOS/releases/
+
+## Where to Install Klipper:
+**NOTE: For now, at least, this repo assumes you will install the Mainsail or Fluidd Klipper package on a Raspberry Pi.
+If you intend to install Klipper on a different host, you will need to research the particulars of how that is done, elsewhere.**
+
+Once you have Klipper installed and configured on the Pi, you must also "make" a binary file to flash to your printer's motherboard(s*) (*Klipper can support connecting multiple motherboards to the same Pi and the same printer)  The pi and Klipper will control the printer, via serial communications over the USB cable, with the bin file on the motherboard.
+
+## How to Install the Fluidd or Mainsail Klipper package onto the Pi:
 
 The image is burned to an SDcard as described here:
 * https://www.raspberrypi.org/documentation/installation/installing-images/
@@ -44,19 +51,25 @@ The latest Raspberry Pi imager V1.7.1 and higher lets us set the username and pa
 Also SSH can be enabled from the imager. This is done through the Settings gearwheel in the bottom right corner.
 Mainsail can now be downloaded and installed directly through the Raspberry Pi Imager
 ```
-## Find and copy the CR6.cfg file and the Printer.<motherboard>.cfg file specific to your printer
+## Find the applicable CR6.cfg file and the Printer.<motherboard>.cfg files in (the Klipper_config folder of this repository)[https://github.com/KoenVanduffel/CR-6_Klipper/tree/main/klipper_config]
 
-Copy the printer definition for your motherboard from this repo to the pi and rename it, "klipper.cfg". 
-* Select the appropriate .cfg file for your motherboard and copy it to /home/pi/klipper_config on the pi
-* Rename that file from "printer.<motherboard>.cfg" to "klipper.cfg"
+In the klipper_config folder of this repo, you will find the following files:
+* CR6.cfg - contains the Klipper software configuration information specific to our CR6 printer.  
+  Use that file for all motherboards.
+* Multiple files with the name Printer.<motherboard>.cfg
+  , where <motherboard> is the name of the motherboard supported by that particular file (e.g. printer.Creality-4.5.3.cfg is the file to use if you have either the 4.5.3 or the 1.1.0.3-ERA motherboard from Creality.)  Use ONLY the printer.<motherboard>.cfg named for your motherboard.
 
-Copy the CR6.cfg file from this repo to the pi, as that contains the Klipper configuration instructions specific to our CR6 printer.  
-* For all motherboards copy CR6.cfg to /home/pi/klipper_config on the pi
-* Do NOT rename that file
+##  Install those two cfg files onto the pi
+ 
+Copy CR6.cfg to /home/pi/klipper_config on the pi
+Do NOT rename that file
+
+Copy the appropriate printer.<motherboard>.cfg file to /home/pi/klipper_config on the pi
+Rename that file from "printer.<motherboard>.cfg" to "klipper.cfg"
 
 ## Now make the actual firmware to be flashed to the printer mainboard
 
-For your convenience, precompiled firmwares have been provided in the firmware directory. For now the BTT CR6 is tested and in use by myself. The stock Creality one is only confirmed to connect properly to my old 4.5.2 board. I have not actually printed with it. Please leave feedback if you use them, so I can confirm they are working.
+_NOTE: For your convenience, precompiled firmwares have been provided in the firmware directory. For now the BTT CR6 is tested and in use by myself. The stock Creality one is only confirmed to connect properly to my old 4.5.2 board. I have not actually printed with it. Please leave feedback if you use them, so I can confirm they are working._
 
 For all stock creality boards, set the following config:
 ```bash
@@ -94,20 +107,25 @@ The screen should now look **exactly** like this for the BTT CR6 board:
 make
 ```
 
-The make command will build the actual firmware to be flashed to the printer and output the file /home/pi/klipper/out/klipper.bin
+## Copy the bin file output by the "make" command to an SD Card, and flash it to the printer
+ 
+The make command will build the actual firmware to be flashed to the printer and will output the file as klipper.bin in the pi directory /home/pi/klipper/out/
 
 Download klipper.bin, rename it to firmware.bin and write it to an SD card
 
 <span style="color:red">
 
-## The SDcard HAS TO BE maximum 16 GB formatted as FAT32 with 4096 bits sector size.
+## The SDcard used to flash the motherboard MUST be formatted as FAT32 with 4096 bits sector size.
 
 ## Any other format and the processor simply cannot read the SD card.
 </span>
 
 A micro-SDcard in an SD adapter works perfectly fine, as long as the formatting is correct.
 
-The last step is to give Klipper the address of the USB connection. To obtain the address in the ssh terminal, run:
+## Obtain the USB connection address and update the [mcu] section of Klipper.cfg
+ 
+The last step is to give Klipper the correct address for the USB connection. 
+To obtain the address in the ssh terminal, run:
 
 ```bash
 ls /dev/serial/by-id/*
@@ -118,9 +136,9 @@ the output should look like this (NOTE: the actual address will differ on yours)
 /dev/serial/by-id/usb-Klipper_stm32f103xe_36FFD8054255373740662057-if00
 ```
 
-Copy the actual text of that line ton your system to the [mcu] section of Klipper.cfg to **replace** the string present there
+Replace the placeholder string in the [mcu] section of Klipper.cfg with actual output string displayed in your terminal 
 
-## From this point on, you should have a working Klipper installation, which now needs to be verified fully functional.
+## From this point on, you should have a working Klipper installation, the full functionality of which you should now verify.
 
 Proceed to the functionality checks as described on the Klipper site: https://www.klipper3d.org/Config_checks.html
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
-# CR-6 Klipper configuration helper
-A repository for Klipper firmware details for the Creality CR-6 printers.
-This repo focusses on using Klipper and the Fluidd front end. In this configuration there is no need for OctoPi - Fluidd is way more responsive than OctoPi.
+# Here is Configuration Help for Using Klipper on CR6 printers
 
-This has been tested on a BTT CR6 board by myself. The 4.5.2, 4.5.3 and ERA boards have been reported to work correctly.
+PLEASE NOTE: The intention of this GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  It is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
 
-Bear in mind that the CR-6 screen will not work (yet) with Klipper. The Fluid interface runs on any PC or mobile device in a standard web browser. As an alternative to the CR-6 screen, KlipperScreen can be used. KlipperScreen runs on a series of Raspberry pi touch screens or on an old phone. Please check out [the KlipperScreen GitHub](https://github.com/jordanruthe/KlipperScreen) for detailed info.
+This repo focusses on using Klipper with the Fluidd front end. 
+
+With this configuration, there is no need for OctoPi - Fluidd is much more responsive than OctoPi.
+
+These resources have been tested on a CR6-SE printer with a BTT SKR CR6 board. The 4.5.2, 4.5.3 and ERA boards have been reported to work correctly with these resources.
+
+Bear in mind that the CR-6 screen will not work (yet) with Klipper. 
+
+The Fluid interface runs on any PC or mobile device in a standard web browser. 
+
+As an alternative to the CR-6 screen, KlipperScreen can be used. KlipperScreen runs on a series of Raspberry pi touch screens or on an old phone. Please check out [the KlipperScreen GitHub](https://github.com/jordanruthe/KlipperScreen) for detailed info.
 
 # What is Klipper?
-Klipper is a complete package to run your 3D printer consisting of 3 main tools:
+Klipper is a complete package to run your 3D printer.
+
+Unlike Marlin and the Marlin-based Community Firmware:
+* The parts of Klipper that convert the gcode into printer instructions run on a separate host processor (like a Raspberry Pi), not on the printer motherboard
+* Klipper makes a binary file that you do flash to the motherboard, but that firmware is only required to implement the printer instructions given to it by Klipper, over the USB serial interface.
+* Klipper does not (yet*) communicate with the touchscreen hardware, so that touchscreen becomes "irrelevant" and unused, when you are running Klipper. (*We are, however, working on a DWIN display project that we hope will restore some functionality to that screen for the CR6Community members who migrate to Klipper.  Stay tuned!)
+
+The Klipper package is comprised of 3 main tools:
 * Klippy: the service running the printer. Klippy interpretes the gcode, produces move commands and sends these to the printer. Klippy is where the heavy lifting is actually done.
 * Moonraker: The broker. Moonraker handles the communication between Klippy, the visual front end(s) and hardware on the rPi.
 * Fluidd/Mainsail/KlipperScreen: The Klipper display and User Interface. These all 3 do more or less the same (you only need one of them but can run all 3 if wanted). They are the user interface where we put/upload our gcode files, do all calibrations, view a bed mesh and so on.
@@ -25,7 +40,7 @@ Once you have Klipper installed and configured on the Pi, you must also "make" a
 
 ## How to Install the Fluidd or Mainsail Klipper package onto the Pi:
 
-The image is burned to an SDcard as described here:
+You can burn the FLuidd or Mainsail Klipper image to an SDcard usng the Raspberry Pi Imager application, as described here:
 * https://www.raspberrypi.org/documentation/installation/installing-images/
 
 In the Raspberry pi Imager click **Chose OS** - **Use Custom** and select the just downloaded image. The rest of the install procedure is the same as on the raspberry page.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Here is Configuration Help for Using Klipper on CR6 printers
+# Here is Help for Installing and Configuring Klipper on CR6 printers
 
 PLEASE NOTE: The intention of this GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  It is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
 
@@ -82,7 +82,7 @@ Do NOT rename that file
 Copy the appropriate printer.<motherboard>.cfg file to /home/pi/klipper_config on the pi
 Rename that file from "printer.<motherboard>.cfg" to "klipper.cfg"
 
-## Now make the actual firmware to be flashed to the printer mainboard
+## Now make the Klipper firmware.bin file that you will flash to the printer mainboard
 
 _NOTE: For your convenience, precompiled firmwares have been provided in the firmware directory. For now the BTT CR6 is tested and in use by myself. The stock Creality one is only confirmed to connect properly to my old 4.5.2 board. I have not actually printed with it. Please leave feedback if you use them, so I can confirm they are working._
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Copy CR6.cfg to /home/pi/klipper_config on the pi
 Do NOT rename that file
 
 Copy the appropriate printer._motherboard_.cfg file to /home/pi/klipper_config on the pi
-Rename that file from "printer._motherboard_.cfg" to "klipper.cfg"
+Rename that file from "printer._motherboard_.cfg" to "printer.cfg"
 
 ## Now make the Klipper firmware.bin file that you will flash to the printer mainboard
 
@@ -141,7 +141,7 @@ Download klipper.bin, rename it to firmware.bin and write it to an SD card
 
 A micro-SDcard in an SD adapter works perfectly fine, as long as the formatting is correct.
 
-## Obtain the USB connection address and update the [mcu] section of Klipper.cfg
+## Obtain the USB connection address and update the [mcu] section of printer.cfg
  
 The last step is to give Klipper the correct address for the USB connection. 
 To obtain the address in the ssh terminal, run:
@@ -155,7 +155,7 @@ the output should look like this (NOTE: the actual address will differ on yours)
 /dev/serial/by-id/usb-Klipper_stm32f103xe_36FFD8054255373740662057-if00
 ```
 
-Replace the placeholder string in the [mcu] section of Klipper.cfg with actual output string displayed in your terminal 
+Replace the placeholder string in the [mcu] section of print.cfg with actual output string displayed in your terminal 
 
 ## From this point on, you should have a working Klipper installation, the full functionality of which you should now verify.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Here is Help for Installing and Configuring Klipper on CR6 printers
 
-PLEASE NOTE: The intention of this GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  It is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
+PLEASE NOTE: 
+* The intention of this GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  
+* This is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
+* YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU (NOTE, though, that NERO3D uses Balener Etcher instead of the Raspberry Pi Imager, in his install)
 
 This repo focusses on using Klipper with the Fluidd front end. 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The latest Raspberry Pi imager V1.7.1 and higher lets us set the username and pa
 Also SSH can be enabled from the imager. This is done through the Settings gearwheel in the bottom right corner.
 Mainsail can now be downloaded and installed directly through the Raspberry Pi Imager
 ```
-## Find the applicable CR6.cfg file and the Printer._motherboard_.cfg files in (the Klipper_config folder of this repository)[https://github.com/KoenVanduffel/CR-6_Klipper/tree/main/klipper_config]
+## Find the applicable CR6.cfg file and the Printer._motherboard_.cfg files in [the Klipper_config folder of this repository](https://github.com/KoenVanduffel/CR-6_Klipper/tree/main/klipper_config)
 
 In the klipper_config folder of this repo, you will find the following files:
 * CR6.cfg - contains the Klipper software configuration information specific to our CR6 printer.  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 PLEASE NOTE: 
 * This GitHub repository provides pre-compiled resources and "how-to" guideance sufficient for you to find, install and configure Klipper firmware on Creality CR-6 printers.  
 * This is NOT an in-depth tutorial on Klipper itself. You may need to supplement the information here and research answers to some questions elsewhere, before being able to understand and use some elements on this site.
-* YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU (NOTE, though, that NERO3D uses [Balena Etcher](https://www.balena.io/etcher/) instead of the Raspberry Pi Imager, to flash Fluidd to his SD.)
+* YouTuber NERO3D is one reliable source of more detailed information and tutorials for installing and configuring Klipper. This tutorial of his for installing the Fluidd/Klipper combo on an Ender3 V2 is a good example: https://www.youtube.com/watch?v=gfZ9Lbyh8qU (NOTE, though, that NERO3D uses [Balena Etcher](https://www.balena.io/etcher/) instead of the [Raspberry Pi Imager](https://www.raspberrypi.com/news/raspberry-pi-imager-imaging-utility/), to flash Fluidd to his SD.)
 
 This repo focusses on using Klipper with the Fluidd front end. 
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ This repo focusses on using Klipper and the Fluidd front end. In this configurat
 
 This has been tested on a BTT CR6 board by myself. The 4.5.2, 4.5.3 and ERA boards have been reported to work correctly.
 
-Bear in mind that the CR-6 screen will not work (yet) with Klipper. The Fluid interface runs on any PC or mobile device in a standard web browser. As an alternative to the CR-6 screen KlipperScreen can be used. KlipperScreen runs on a series of Raspberry pi touch screens or on an old phone. Please check out the KlipperScreen GitHub for detailed info.
-# What is Klipper
-Klipper is a complete package to run your 3D printer consisting of a series of 3 main tools:
-* Klippy: the service running the printer. Klippy interpretes the gcode, produces move commands and sends these to the printer. Klippy is where the heavy lifting is actully done.
+Bear in mind that the CR-6 screen will not work (yet) with Klipper. The Fluid interface runs on any PC or mobile device in a standard web browser. As an alternative to the CR-6 screen, KlipperScreen can be used. KlipperScreen runs on a series of Raspberry pi touch screens or on an old phone. Please check out [the KlipperScreen GitHub](https://github.com/jordanruthe/KlipperScreen) for detailed info.
+
+# What is Klipper?
+Klipper is a complete package to run your 3D printer consisting of 3 main tools:
+* Klippy: the service running the printer. Klippy interpretes the gcode, produces move commands and sends these to the printer. Klippy is where the heavy lifting is actually done.
 * Moonraker: The broker. Moonraker handles the communication between Klippy, the visual front end(s) and hardware on the rPi.
-* Fluidd, Mainsail, KlipperScreen: The display and interface of Klipper. These all 3 do more or less the same (you only need one of them but can run all 3 if wanted). They are the user interface where we put/upload our gcode files, do all calibrations, view a bed mesh and so on.
+* Fluidd/Mainsail/KlipperScreen: The Klipper display and User Interface. These all 3 do more or less the same (you only need one of them but can run all 3 if wanted). They are the user interface where we put/upload our gcode files, do all calibrations, view a bed mesh and so on.
 
 ## Installation description:
 
@@ -25,7 +26,7 @@ In the Raspberry pi Imager click **Chose OS** - **Use Custom** and select the ju
 Setup WiFi if needed:
 * https://www.raspberrypi.org/documentation/configuration/wireless/headless.md
 
-The default user and passowrd are **pi** and **raspberry**. We need to change the default password.
+The default user and password are **pi** and **raspberry**. We need to change the default password.
 
 Use MobaXterm (or equivalent) as it is an SSH client and remote file system in one to change the password and copy a few files onto the PI.
 
@@ -34,29 +35,30 @@ For people not used to work with Raspberry PI's https://www.raspberrypi-spy.co.u
 After starting up the PI FIRST run :
 ```bash
  sudo raspi-config
-          set a new passowrd (optiion 1, S3), optionally change the system name
+          set a new password (option 1, S3), optionally change the system name
  sudo reboot
 ```
 
 ```
-The latest Raspberry Pi imager V1.7.1 and higher let us set the username and password from the imager.
-Also SSH can be enabled from the imager. This is done trough the gearwheel in the bottom right.
-Further Mainsail can now be downloaded and installed directly trough the Raspberry Pi Imager
+The latest Raspberry Pi imager V1.7.1 and higher lets us set the username and password from the imager.
+Also SSH can be enabled from the imager. This is done through the Settings gearwheel in the bottom right corner.
+Mainsail can now be downloaded and installed directly through the Raspberry Pi Imager
 ```
+## Find and copy the CR6.cfg file and the Printer.<motherboard>.cfg file specific to your printer
 
-Now we need to copy the printer definition from this repo to the main printer.cfg file. Next to the printer.cfg file also the CR6.cfg file needs to be copied as it contains the specific things of the CR-6 style printers.
+Copy the printer definition for your motherboard from this repo to the pi and rename it, "klipper.cfg". 
+* Select the appropriate .cfg file for your motherboard and copy it to /home/pi/klipper_config on the pi
+* Rename that file from "printer.<motherboard>.cfg" to "klipper.cfg"
 
-Select the config file appropriate for your motherboard and copy it to /home/pi/klipper_config
+Copy the CR6.cfg file from this repo to the pi, as that contains the Klipper configuration instructions specific to our CR6 printer.  
+* For all motherboards copy CR6.cfg to /home/pi/klipper_config on the pi
+* Do NOT rename that file
 
-Rename the file to klipper.cfg
+## Now make the actual firmware to be flashed to the printer mainboard
 
-For all motherboards copy CR6.cfg to /home/pi/klipper_config
+For your convenience, precompiled firmwares have been provided in the firmware directory. For now the BTT CR6 is tested and in use by myself. The stock Creality one is only confirmed to connect properly to my old 4.5.2 board. I have not actually printed with it. Please leave feedback if you use them, so I can confirm they are working.
 
-## Now we can make the actual firmware to be flashed to the printer mainboard
-
-For convenience precompiled firmwares have been provided in the firmware directory. For now the BTT CR6 is tested and in use by myself, the stock Creality one is only confirmed to connect properly to my old 4.5.2 board. I have not actually printed with it. Please mention your mileage so I can confirm their working.
-
-For all stock creality boards set the following config:
+For all stock creality boards, set the following config:
 ```bash
 cd klipper
 sudo service klipper stop
@@ -78,12 +80,12 @@ For the BTT CR6 board:
             set GPIO pins to set at micro-controller startup to "!PA14"
 ```
 
-The screen should now **exactly** look like this for the 4.5.2, 4.5.3 and ERA boards:
+The screen should now look **exactly** like this for the 4.5.2, 4.5.3 and ERA boards:
 
 ![image](https://user-images.githubusercontent.com/13643644/125346549-2e670f80-e35a-11eb-8940-d584d0bb70d7.png)
 
 
-The screen should now **exactly** look like this for the BTT CR6 board:
+The screen should now look **exactly** like this for the BTT CR6 board:
 
 ![image](https://user-images.githubusercontent.com/13643644/123483020-6a823c80-d606-11eb-8dfc-3924ef9c4a7f.png)
 
@@ -94,7 +96,7 @@ make
 
 The make command will build the actual firmware to be flashed to the printer and output the file /home/pi/klipper/out/klipper.bin
 
-download klipper.bin, rename it to firmware.bin and write to an SD card
+Download klipper.bin, rename it to firmware.bin and write it to an SD card
 
 <span style="color:red">
 
@@ -103,19 +105,22 @@ download klipper.bin, rename it to firmware.bin and write to an SD card
 ## Any other format and the processor simply cannot read the SD card.
 </span>
 
-A micro-SDcard in and SD adapter works perfectly fine as long as the formatting is correct.
+A micro-SDcard in an SD adapter works perfectly fine, as long as the formatting is correct.
 
-The last step is to give Klipper the address of the USB connection. To ontain the addres in the ssh terminal run:
+The last step is to give Klipper the address of the USB connection. To obtain the address in the ssh terminal, run:
+
 ```bash
 ls /dev/serial/by-id/*
 ```
 
-the output should looke like this:
+the output should look like this (NOTE: the actual address will differ on yours):
 ```bash
 /dev/serial/by-id/usb-Klipper_stm32f103xe_36FFD8054255373740662057-if00
 ```
 
-Copy this to the [mcu] section of Klipper.cfg and replace the string present there
-## From this point you should have a working Klipper installation.
-You can proceed to the functionality checks as described on the Klipper site: https://www.klipper3d.org/Config_checks.html
+Copy the actual text of that line ton your system to the [mcu] section of Klipper.cfg to **replace** the string present there
+
+## From this point on, you should have a working Klipper installation, which now needs to be verified fully functional.
+
+Proceed to the functionality checks as described on the Klipper site: https://www.klipper3d.org/Config_checks.html
 

--- a/klipper_config/CR6.cfg
+++ b/klipper_config/CR6.cfg
@@ -11,6 +11,9 @@ horizontal_move_z: 5
 mesh_min: 5,5
 mesh_max: 230,230
 probe_count: 6,6
+fade_start: 1
+fade_end: 10
+fade_target: 0
 
 [safe_z_home]
 home_xy_position: 117.5,117.5

--- a/klipper_config/printer.BTT-SKR-CR6.cfg
+++ b/klipper_config/printer.BTT-SKR-CR6.cfg
@@ -184,7 +184,3 @@ max_z_accel: 100
 
 [static_digital_output usb_pullup_enable]
 pins: !PA14
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-


### PR DESCRIPTION
I found a bug in the Printer.BTT-SKR-CR6.cfg file:

These two lines at the bottom of the file cause problems with Klipper: 

#*# <---------------------- SAVE_CONFIG ---------------------->
#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.

Klipper wants to write those lines itself.  With those lines in the file, Klipper keeps adding that header again after one blank line below the last #*# line, again and again, every time a CONFIG_SAVE command is used.  Klipper can not, then, read the saved configuration data, so it fails to retrieve and apply the bed mesh, for instance...

I also found that fade height is missing from the [bed_mesh] profile in CR6.cfg
I have proposed 10mm fade height, same as the CF6.1 defaults.

The other commits are editorials I have been making in the Readme in my fork, as I slowly learn & explain to myself what this is all about.  I had floated those proposed edits to you in PR#4, but when I made this new PR, I did not pay attention when the branch was spawned from the Editorials branch instead of from main.  
Sorry for the confusion. Still learning how to organize my workflow with GitHub.  At least this way, you can see my edits all at once, instead of bit by bit.